### PR TITLE
Avoid unnecessary set_pulse_register

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,8 @@
-Checklist befor review:
+Checklist before review:
 - [ ] Task A
 - [ ] Task B
 
 Checklist before merge:
 - [ ] Reviewers confirm new code works as expected.
 - [ ] Tests are passing.
-- [ ] Coverage does not decrease.
 - [ ] Documentation is updated.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@ Repository for developing server side of RFSoC fpga boards
 Qibosoq is a server for integrating [Qick](https://github.com/openquantumhardware/qick) in the [Qibolab](https://github.com/qiboteam/qibolab) ecosystem
 for executing arbitrary pulses sequences on QPUs.
 
-## Installation 
-The package can be installed by source: 
+The complete documentation can be found at [qibo.science/qibosoq/stable](https://qibo.science/qibosoq/stable/)
+
+## Installation
+The package can be installed by source:
 
 ```sh
 git clone https://github.com/qiboteam/qibosoq.git
@@ -24,9 +26,9 @@ pre-commit install
 ## Hardcoded parameters
 
 In `__main__.py` some qibosoq parameters are hardcoded and can be changed:
-* **host**: the ip of the server
-* **port**: the port of the server
-* **filename**: the path for the logs
+* **host**: ip of the server
+* **port**: port of the server
+* **filename**: path for logs
 
 ## Run the server
 

--- a/doc/source/getting-started/usage.rst
+++ b/doc/source/getting-started/usage.rst
@@ -28,7 +28,7 @@ To avoid it, you can use qibosoq in detached mode, redirecting the output to a l
 
 .. code-block::
 
-    nohup sudo -i python -m qibosoq > logs/mylog &
+    nohup sudo -i python -m qibosoq &
 
 To close the server you will need to find the PID of the process (present in the second line of the log file) and:
 
@@ -39,7 +39,9 @@ To close the server you will need to find the PID of the process (present in the
 Useful aliases
 """"""""""""""
 
-We suggest to add to your ``.bashrc`` some aliases to speed up the process. Some examples are:
+We suggest to add to your ``.bashrc`` some aliases to speed up the process.
+(Note that with ``server-run-bkg`` the sudo password is not requested, but if the shell does not have sudo privileges it will fail.)
+Some examples are:
 
 .. code-block::
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,14 +26,14 @@ files = [
 
 [[package]]
 name = "astroid"
-version = "2.15.4"
+version = "2.15.5"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "astroid-2.15.4-py3-none-any.whl", hash = "sha256:a1b8543ef9d36ea777194bc9b17f5f8678d2c56ee6a45b2c2f17eec96f242347"},
-    {file = "astroid-2.15.4.tar.gz", hash = "sha256:c81e1c7fbac615037744d067a9bb5f9aeb655edf59b63ee8b59585475d6f80d8"},
+    {file = "astroid-2.15.5-py3-none-any.whl", hash = "sha256:078e5212f9885fa85fbb0cf0101978a336190aadea6e13305409d099f71b2324"},
+    {file = "astroid-2.15.5.tar.gz", hash = "sha256:1039262575027b441137ab4a62a793a9b43defb42c32d5670f38686207cd780f"},
 ]
 
 [package.dependencies]
@@ -148,14 +148,14 @@ css = ["tinycss2 (>=1.1.0,<1.2)"]
 
 [[package]]
 name = "certifi"
-version = "2022.12.7"
+version = "2023.5.7"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
-    {file = "certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3"},
+    {file = "certifi-2023.5.7-py3-none-any.whl", hash = "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"},
+    {file = "certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
 ]
 
 [[package]]
@@ -521,14 +521,14 @@ tests = ["asttokens", "littleutils", "pytest", "rich"]
 
 [[package]]
 name = "fastjsonschema"
-version = "2.16.3"
+version = "2.17.1"
 description = "Fastest Python implementation of JSON schema"
 category = "dev"
 optional = false
 python-versions = "*"
 files = [
-    {file = "fastjsonschema-2.16.3-py3-none-any.whl", hash = "sha256:04fbecc94300436f628517b05741b7ea009506ce8f946d40996567c669318490"},
-    {file = "fastjsonschema-2.16.3.tar.gz", hash = "sha256:4a30d6315a68c253cfa8f963b9697246315aa3db89f98b97235e345dedfb0b8e"},
+    {file = "fastjsonschema-2.17.1-py3-none-any.whl", hash = "sha256:4b90b252628ca695280924d863fe37234eebadc29c5360d322571233dc9746e0"},
+    {file = "fastjsonschema-2.17.1.tar.gz", hash = "sha256:f4eeb8a77cef54861dbf7424ac8ce71306f12cbb086c45131bcba2c6a4f726e3"},
 ]
 
 [package.extras]
@@ -536,14 +536,14 @@ devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benc
 
 [[package]]
 name = "fonttools"
-version = "4.39.3"
+version = "4.39.4"
 description = "Tools to manipulate font files"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "fonttools-4.39.3-py3-none-any.whl", hash = "sha256:64c0c05c337f826183637570ac5ab49ee220eec66cf50248e8df527edfa95aeb"},
-    {file = "fonttools-4.39.3.zip", hash = "sha256:9234b9f57b74e31b192c3fc32ef1a40750a8fbc1cd9837a7b7bfc4ca4a5c51d7"},
+    {file = "fonttools-4.39.4-py3-none-any.whl", hash = "sha256:106caf6167c4597556b31a8d9175a3fdc0356fdcd70ab19973c3b0d4c893c461"},
+    {file = "fonttools-4.39.4.zip", hash = "sha256:dba8d7cdb8e2bac1b3da28c5ed5960de09e59a2fe7e63bb73f5a59e57b0430d2"},
 ]
 
 [package.extras]
@@ -562,20 +562,20 @@ woff = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "zopfli (>=0.1.4)"]
 
 [[package]]
 name = "furo"
-version = "2023.3.27"
+version = "2023.5.20"
 description = "A clean customisable Sphinx documentation theme."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "furo-2023.3.27-py3-none-any.whl", hash = "sha256:4ab2be254a2d5e52792d0ca793a12c35582dd09897228a6dd47885dabd5c9521"},
-    {file = "furo-2023.3.27.tar.gz", hash = "sha256:b99e7867a5cc833b2b34d7230631dd6558c7a29f93071fdbb5709634bb33c5a5"},
+    {file = "furo-2023.5.20-py3-none-any.whl", hash = "sha256:594a8436ddfe0c071f3a9e9a209c314a219d8341f3f1af33fdf7c69544fab9e6"},
+    {file = "furo-2023.5.20.tar.gz", hash = "sha256:40e09fa17c6f4b22419d122e933089226dcdb59747b5b6c79363089827dea16f"},
 ]
 
 [package.dependencies]
 beautifulsoup4 = "*"
 pygments = ">=2.7"
-sphinx = ">=5.0,<7.0"
+sphinx = ">=6.0,<8.0"
 sphinx-basic-ng = "*"
 
 [[package]]
@@ -643,14 +643,14 @@ testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-chec
 
 [[package]]
 name = "ipython"
-version = "8.12.0"
+version = "8.12.2"
 description = "IPython: Productive Interactive Computing"
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "ipython-8.12.0-py3-none-any.whl", hash = "sha256:1c183bf61b148b00bcebfa5d9b39312733ae97f6dad90d7e9b4d86c8647f498c"},
-    {file = "ipython-8.12.0.tar.gz", hash = "sha256:a950236df04ad75b5bc7f816f9af3d74dc118fd42f2ff7e80e8e60ca1f182e2d"},
+    {file = "ipython-8.12.2-py3-none-any.whl", hash = "sha256:ea8801f15dfe4ffb76dea1b09b847430ffd70d827b41735c64a0638a04103bfc"},
+    {file = "ipython-8.12.2.tar.gz", hash = "sha256:c7b80eb7f5a855a88efc971fda506ff7a91c280b42cdae26643e0f601ea281ea"},
 ]
 
 [package.dependencies]
@@ -1202,14 +1202,14 @@ test = ["flaky", "ipykernel", "ipython", "ipywidgets", "nbconvert (>=7.0.0)", "p
 
 [[package]]
 name = "nbconvert"
-version = "7.3.1"
+version = "7.4.0"
 description = "Converting Jupyter Notebooks"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "nbconvert-7.3.1-py3-none-any.whl", hash = "sha256:d2e95904666f1ff77d36105b9de4e0801726f93b862d5b28f69e93d99ad3b19c"},
-    {file = "nbconvert-7.3.1.tar.gz", hash = "sha256:78685362b11d2e8058e70196fe83b09abed8df22d3e599cf271f4d39fdc48b9e"},
+    {file = "nbconvert-7.4.0-py3-none-any.whl", hash = "sha256:af5064a9db524f9f12f4e8be7f0799524bd5b14c1adea37e34e83c95127cc818"},
+    {file = "nbconvert-7.4.0.tar.gz", hash = "sha256:51b6c77b507b177b73f6729dba15676e42c4e92bcb00edc8cc982ee72e7d89d7"},
 ]
 
 [package.dependencies]
@@ -1511,18 +1511,18 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "3.4.0"
+version = "3.5.1"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.4.0-py3-none-any.whl", hash = "sha256:01437886022decaf285d8972f9526397bfae2ac55480ed372ed6d9eca048870a"},
-    {file = "platformdirs-3.4.0.tar.gz", hash = "sha256:a5e1536e5ea4b1c238a1364da17ff2993d5bd28e15600c2c8224008aff6bbcad"},
+    {file = "platformdirs-3.5.1-py3-none-any.whl", hash = "sha256:e2378146f1964972c03c085bb5662ae80b2b8c06226c54b2ff4aa9483e8a13a5"},
+    {file = "platformdirs-3.5.1.tar.gz", hash = "sha256:412dae91f52a6f84830f39a8078cecd0e866cb72294a5c66808e74d5e88d251f"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
+docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.2.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
@@ -1712,14 +1712,14 @@ plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pylint"
-version = "2.17.3"
+version = "2.17.4"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "pylint-2.17.3-py3-none-any.whl", hash = "sha256:a6cbb4c6e96eab4a3c7de7c6383c512478f58f88d95764507d84c899d656a89a"},
-    {file = "pylint-2.17.3.tar.gz", hash = "sha256:761907349e699f8afdcd56c4fe02f3021ab5b3a0fc26d19a9bfdc66c7d0d5cd5"},
+    {file = "pylint-2.17.4-py3-none-any.whl", hash = "sha256:7a1145fb08c251bdb5cca11739722ce64a63db479283d10ce718b2460e54123c"},
+    {file = "pylint-2.17.4.tar.gz", hash = "sha256:5dcf1d9e19f41f38e4e85d10f511e5b9c35e1aa74251bf95cdd8cb23584e2db1"},
 ]
 
 [package.dependencies]
@@ -2076,20 +2076,16 @@ description = "Quantum hardware module and drivers for Qibo"
 category = "main"
 optional = false
 python-versions = ">=3.8,<3.12"
-files = []
-develop = false
+files = [
+    {file = "qibolab-0.0.3-py3-none-any.whl", hash = "sha256:a8b9eab0d4308553fac6185119bb39606aac21c6fb470553e1ec8c9b42ad4b14"},
+    {file = "qibolab-0.0.3.tar.gz", hash = "sha256:ae4156cc7f7679316090f329bf481e31e4e399754af2b9ce0464a52919bfb0e0"},
+]
 
 [package.dependencies]
-more-itertools = "^9.1.0"
-networkx = "^3.0"
-pyyaml = "^6.0"
-qibo = "^0.1.12"
-
-[package.source]
-type = "git"
-url = "https://github.com/qiboteam/qibolab.git"
-reference = "main"
-resolved_reference = "dc453507ca557da82e4c6dee74e056832e4be519"
+more-itertools = ">=9.1.0,<10.0.0"
+networkx = ">=3.0,<4.0"
+pyyaml = ">=6.0,<7.0"
+qibo = ">=0.1.12,<0.2.0"
 
 [[package]]
 name = "qick"
@@ -2127,21 +2123,21 @@ sphinx = ">=1.3.1"
 
 [[package]]
 name = "requests"
-version = "2.29.0"
+version = "2.30.0"
 description = "Python HTTP for Humans."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "requests-2.29.0-py3-none-any.whl", hash = "sha256:e8f3c9be120d3333921d213eef078af392fba3933ab7ed2d1cba3b56f2568c3b"},
-    {file = "requests-2.29.0.tar.gz", hash = "sha256:f2e34a75f4749019bb0e3effb66683630e4ffeaf75819fb51bebef1bf5aef059"},
+    {file = "requests-2.30.0-py3-none-any.whl", hash = "sha256:10e94cc4f3121ee6da529d358cdaeaff2f1c409cd377dbc72b825852f2f7e294"},
+    {file = "requests-2.30.0.tar.gz", hash = "sha256:239d7d4458afcb28a692cdd298d87542235f4ca8d36d03a15bfc128a6559a2f4"},
 ]
 
 [package.dependencies]
 certifi = ">=2017.4.17"
 charset-normalizer = ">=2,<4"
 idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<1.27"
+urllib3 = ">=1.21.1,<3"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
@@ -2188,19 +2184,19 @@ test = ["asv", "gmpy2", "mpmath", "pooch", "pytest", "pytest-cov", "pytest-timeo
 
 [[package]]
 name = "setuptools"
-version = "67.7.2"
+version = "67.8.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.7.2-py3-none-any.whl", hash = "sha256:23aaf86b85ca52ceb801d32703f12d77517b2556af839621c641fca11287952b"},
-    {file = "setuptools-67.7.2.tar.gz", hash = "sha256:f104fa03692a2602fa0fec6c6a9e63b6c8a968de13e17c026957dd1f53d80990"},
+    {file = "setuptools-67.8.0-py3-none-any.whl", hash = "sha256:5df61bf30bb10c6f756eb19e7c9f3b473051f48db77fddbe06ff2ca307df9a6f"},
+    {file = "setuptools-67.8.0.tar.gz", hash = "sha256:62642358adc77ffa87233bc4d2354c4b2682d214048f500964dbe760ccedf102"},
 ]
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
@@ -2463,14 +2459,14 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
 name = "sympy"
-version = "1.11.1"
+version = "1.12"
 description = "Computer algebra system (CAS) in Python"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "sympy-1.11.1-py3-none-any.whl", hash = "sha256:938f984ee2b1e8eae8a07b884c8b7a1146010040fccddc6539c54f401c8f6fcf"},
-    {file = "sympy-1.11.1.tar.gz", hash = "sha256:e32380dce63cb7c0108ed525570092fd45168bdae2faa17e528221ef72e88658"},
+    {file = "sympy-1.12-py3-none-any.whl", hash = "sha256:c3588cd4295d0c0f603d0f2ae780587e64e2efeedb3521e46b9bb1d08d184fa5"},
+    {file = "sympy-1.12.tar.gz", hash = "sha256:ebf595c8dac3e0fdc4152c51878b498396ec7f30e7a914d6071e674d49420fb8"},
 ]
 
 [package.dependencies]
@@ -2536,23 +2532,23 @@ files = [
 
 [[package]]
 name = "tornado"
-version = "6.3.1"
+version = "6.3.2"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
 category = "dev"
 optional = false
 python-versions = ">= 3.8"
 files = [
-    {file = "tornado-6.3.1-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:db181eb3df8738613ff0a26f49e1b394aade05034b01200a63e9662f347d4415"},
-    {file = "tornado-6.3.1-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b4e7b956f9b5e6f9feb643ea04f07e7c6b49301e03e0023eedb01fa8cf52f579"},
-    {file = "tornado-6.3.1-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9661aa8bc0e9d83d757cd95b6f6d1ece8ca9fd1ccdd34db2de381e25bf818233"},
-    {file = "tornado-6.3.1-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:81c17e0cc396908a5e25dc8e9c5e4936e6dfd544c9290be48bd054c79bcad51e"},
-    {file = "tornado-6.3.1-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a27a1cfa9997923f80bdd962b3aab048ac486ad8cfb2f237964f8ab7f7eb824b"},
-    {file = "tornado-6.3.1-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:d7117f3c7ba5d05813b17a1f04efc8e108a1b811ccfddd9134cc68553c414864"},
-    {file = "tornado-6.3.1-cp38-abi3-musllinux_1_1_i686.whl", hash = "sha256:ffdce65a281fd708da5a9def3bfb8f364766847fa7ed806821a69094c9629e8a"},
-    {file = "tornado-6.3.1-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:90f569a35a8ec19bde53aa596952071f445da678ec8596af763b9b9ce07605e6"},
-    {file = "tornado-6.3.1-cp38-abi3-win32.whl", hash = "sha256:3455133b9ff262fd0a75630af0a8ee13564f25fb4fd3d9ce239b8a7d3d027bf8"},
-    {file = "tornado-6.3.1-cp38-abi3-win_amd64.whl", hash = "sha256:1285f0691143f7ab97150831455d4db17a267b59649f7bd9700282cba3d5e771"},
-    {file = "tornado-6.3.1.tar.gz", hash = "sha256:5e2f49ad371595957c50e42dd7e5c14d64a6843a3cf27352b69c706d1b5918af"},
+    {file = "tornado-6.3.2-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:c367ab6c0393d71171123ca5515c61ff62fe09024fa6bf299cd1339dc9456829"},
+    {file = "tornado-6.3.2-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b46a6ab20f5c7c1cb949c72c1994a4585d2eaa0be4853f50a03b5031e964fc7c"},
+    {file = "tornado-6.3.2-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c2de14066c4a38b4ecbbcd55c5cc4b5340eb04f1c5e81da7451ef555859c833f"},
+    {file = "tornado-6.3.2-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:05615096845cf50a895026f749195bf0b10b8909f9be672f50b0fe69cba368e4"},
+    {file = "tornado-6.3.2-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5b17b1cf5f8354efa3d37c6e28fdfd9c1c1e5122f2cb56dac121ac61baa47cbe"},
+    {file = "tornado-6.3.2-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:29e71c847a35f6e10ca3b5c2990a52ce38b233019d8e858b755ea6ce4dcdd19d"},
+    {file = "tornado-6.3.2-cp38-abi3-musllinux_1_1_i686.whl", hash = "sha256:834ae7540ad3a83199a8da8f9f2d383e3c3d5130a328889e4cc991acc81e87a0"},
+    {file = "tornado-6.3.2-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:6a0848f1aea0d196a7c4f6772197cbe2abc4266f836b0aac76947872cd29b411"},
+    {file = "tornado-6.3.2-cp38-abi3-win32.whl", hash = "sha256:7efcbcc30b7c654eb6a8c9c9da787a851c18f8ccd4a5a3a95b05c7accfa068d2"},
+    {file = "tornado-6.3.2-cp38-abi3-win_amd64.whl", hash = "sha256:0c325e66c8123c606eea33084976c832aa4e766b7dff8aedd7587ea44a604cdf"},
+    {file = "tornado-6.3.2.tar.gz", hash = "sha256:4b927c4f19b71e627b13f3db2324e4ae660527143f9e1f2e2fb404f3a187e2ba"},
 ]
 
 [[package]]
@@ -2606,20 +2602,21 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "1.26.15"
+version = "2.0.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=3.7"
 files = [
-    {file = "urllib3-1.26.15-py2.py3-none-any.whl", hash = "sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42"},
-    {file = "urllib3-1.26.15.tar.gz", hash = "sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305"},
+    {file = "urllib3-2.0.2-py3-none-any.whl", hash = "sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"},
+    {file = "urllib3-2.0.2.tar.gz", hash = "sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
+socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "wcwidth"
@@ -2749,4 +2746,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8, <3.12"
-content-hash = "4ae220347a8158bcddc9ea4a53e652f45197b118bdf375424f88f59e40bb937f"
+content-hash = "7afa7399ce1782631df1275749ee0af1384719cda5ffc48d01f74bf5fe774fee"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,7 @@ packages = [{ include = "qibosoq", from = "src" }]
 
 [tool.poetry.dependencies]
 python = ">=3.8, <3.12"
-# TODO replace with qibolab = "0.0.3" when released
-qibolab = { git = "https://github.com/qiboteam/qibolab.git", branch  = "main"}
+qibolab = "0.0.3"
 qick = "^0.2"
 
 

--- a/src/qibosoq/__main__.py
+++ b/src/qibosoq/__main__.py
@@ -8,8 +8,8 @@ import sys
 from qibosoq.rfsoc_server import serve
 
 
-def define_logger():
-    """Define logger format and handler"""
+def define_main_logger():
+    """Define main logger format and handler"""
 
     new_logger = logging.getLogger("__name__")
     new_logger.setLevel(logging.DEBUG)
@@ -27,7 +27,24 @@ def define_logger():
     return new_logger
 
 
-logger = define_logger()
+def define_program_logger():
+    """Define qick logger format and handler"""
+
+    new_logger = logging.getLogger("qick_program")
+    new_logger.setLevel(logging.DEBUG)
+
+    filename = "/home/xilinx/logs/program.log"
+    formatter = logging.Formatter("%(levelname)s :: %(asctime)s\n%(message)s", "%Y-%m-%d %H:%M:%S")
+
+    handler = logging.handlers.RotatingFileHandler(filename, mode="w", backupCount=3)
+    handler.setFormatter(formatter)
+
+    new_logger.addHandler(handler)
+    return new_logger
+
+
+logger = define_main_logger()
+program_logger = define_program_logger()
 
 HOST = "192.168.0.72"  # Server address
 PORT = 6000  # Port to listen on

--- a/src/qibosoq/qick_programs.py
+++ b/src/qibosoq/qick_programs.py
@@ -1,5 +1,6 @@
 """ QickPrograms used by qibosoq to execute sequences and sweeps """
 
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import asdict
 from typing import List, Tuple
@@ -14,6 +15,8 @@ from qick import AveragerProgram, QickProgram, QickSoc, RAveragerProgram
 # conversion coefficients (in qibolab we use Hz and ns)
 HZ_TO_MHZ = 1e-6
 NS_TO_US = 1e-3
+
+logger = logging.getLogger("__name__")
 
 
 class GeneralQickProgram(ABC, QickProgram):
@@ -218,16 +221,16 @@ class GeneralQickProgram(ABC, QickProgram):
 
     def is_pulse_equal(self, pulse_a: Pulse, pulse_b: Pulse) -> bool:
         """Check if two pulses are equal, does not check the start time"""
-        if pulse_a is None:
+        if pulse_a is None or pulse_b is None:
             return False
         return (
             pulse_a.frequency == pulse_b.frequency
             and pulse_a.amplitude == pulse_b.amplitude
-            and pulse_a.shape == pulse_b.shape
             and pulse_a.relative_phase == pulse_b.relative_phase
             and pulse_a.duration == pulse_b.duration
             and pulse_a.type == pulse_b.type
         )
+        # and pulse_a.shape == pulse_b.shape
 
     def acquire(
         self,

--- a/src/qibosoq/qick_programs.py
+++ b/src/qibosoq/qick_programs.py
@@ -186,7 +186,7 @@ class GeneralQickProgram(ABC, QickProgram):
 
         last_pulse_registered = {}
         for idx in self.gen_chs:
-            last_pulse_registered[str(idx)] = None
+            last_pulse_registered[idx] = None
 
         for pulse in self.sequence:
             # time follows tproc CLK
@@ -218,6 +218,8 @@ class GeneralQickProgram(ABC, QickProgram):
 
     def is_pulse_equal(self, pulse_a: Pulse, pulse_b: Pulse) -> bool:
         """Check if two pulses are equal, does not check the start time"""
+        if pulse_a is None:
+            return False
         return (
             pulse_a.frequency == pulse_b.frequency
             and pulse_a.amplitude == pulse_b.amplitude

--- a/src/qibosoq/qick_programs.py
+++ b/src/qibosoq/qick_programs.py
@@ -207,7 +207,7 @@ class GeneralQickProgram(ABC, QickProgram):
             gen_ch = qd_ch if pulse.type is PulseType.DRIVE else ro_ch
 
             if not self.pulses_registered:
-                if not self.is_pulse_equal(last_pulse_registered[gen_ch], pulse):
+                if not pulse.is_pulse_equal_ignoring_start(last_pulse_registered[gen_ch]):
                     self.add_pulse_to_register(pulse)
                     last_pulse_registered[gen_ch] = pulse
 
@@ -224,19 +224,6 @@ class GeneralQickProgram(ABC, QickProgram):
                 )
         self.wait_all()
         self.sync_all(self.relax_delay)
-
-    def is_pulse_equal(self, pulse_a: Pulse, pulse_b: Pulse) -> bool:
-        """Check if two pulses are equal, does not check the start time"""
-        if pulse_a is None or pulse_b is None:
-            return False
-        return (
-            pulse_a.frequency == pulse_b.frequency
-            and pulse_a.amplitude == pulse_b.amplitude
-            and pulse_a.relative_phase == pulse_b.relative_phase
-            and pulse_a.duration == pulse_b.duration
-            and pulse_a.type == pulse_b.type
-        )
-        # and pulse_a.shape == pulse_b.shape
 
     def acquire(
         self,

--- a/src/qibosoq/qick_programs.py
+++ b/src/qibosoq/qick_programs.py
@@ -112,7 +112,7 @@ class GeneralQickProgram(ABC, QickProgram):
         # assign gain parameter
         gain_set = False
         if is_sweeped:
-            if self.sweeper.parameter == Parameter.amplitude:
+            if self.sweeper.parameter is Parameter.amplitude:
                 gain = self.cfg["start"]
                 gain_set = True
         if not gain_set:
@@ -133,7 +133,7 @@ class GeneralQickProgram(ABC, QickProgram):
         if pulse.type is PulseType.DRIVE:
             freq_set = False
             if is_sweeped:
-                if self.sweeper.parameter == Parameter.frequency:
+                if self.sweeper.parameter is Parameter.frequency:
                     freq = self.cfg["start"]
                     freq_set = True
             if not freq_set:
@@ -352,12 +352,12 @@ class ExecuteSingleSweep(GeneralQickProgram, RAveragerProgram):
         step = self.sweeper.values[1] - self.sweeper.values[0]
 
         # find register of sweeped parameter and assign start and step
-        if self.sweeper.parameter == Parameter.frequency:
+        if self.sweeper.parameter is Parameter.frequency:
             self.sweeper_reg = self.sreg(gen_ch, "freq")
             self.cfg["start"] = self.soc.freq2reg(start * HZ_TO_MHZ, gen_ch)
             self.cfg["step"] = self.soc.freq2reg(step * HZ_TO_MHZ, gen_ch)
 
-        elif self.sweeper.parameter == Parameter.amplitude:
+        elif self.sweeper.parameter is Parameter.amplitude:
             self.sweeper_reg = self.sreg(gen_ch, "gain")
             self.cfg["start"] = int(start * self.max_gain)
             self.cfg["step"] = int(step * self.max_gain)
@@ -386,7 +386,13 @@ class ExecuteSingleSweep(GeneralQickProgram, RAveragerProgram):
         Returns:
             (bool): True if the pulse is sweeped
         """
-        return self.sweeper.pulses[0] == pulse
+        pulseb = self.sweeper.pulses[0]
+        return (  # temporary solution, already solved for zcu111
+            pulse.start == pulseb.start
+            and pulse.start == pulseb.start
+            and pulse.type == pulseb.type
+            and pulse.qubit == pulseb.qubit
+        )
 
     def update(self):
         """Update function for sweeper"""

--- a/src/qibosoq/rfsoc_server.py
+++ b/src/qibosoq/rfsoc_server.py
@@ -15,6 +15,7 @@ from qick import QickSoc
 from qibosoq.qick_programs import ExecutePulseSequence, ExecuteSingleSweep
 
 logger = logging.getLogger("__name__")
+qick_logger = logging.getLogger("qick_program")
 
 
 class ConnectionHandler(BaseRequestHandler):
@@ -47,6 +48,10 @@ class ConnectionHandler(BaseRequestHandler):
             program = ExecuteSingleSweep(global_soc, data["cfg"], data["sequence"], data["qubits"], data["sweeper"])
         else:
             raise NotImplementedError(f"Operation code {data['operation_code']} not supported")
+
+        qick_logger.handlers[0].doRollover()
+        qick_logger.info(program.asm())
+        logger.info("Program logged!")
 
         toti, totq = program.acquire(
             global_soc,

--- a/src/qibosoq/rfsoc_server.py
+++ b/src/qibosoq/rfsoc_server.py
@@ -51,7 +51,6 @@ class ConnectionHandler(BaseRequestHandler):
 
         qick_logger.handlers[0].doRollover()
         qick_logger.info(program.asm())
-        logger.info("Program logged!")
 
         toti, totq = program.acquire(
             global_soc,
@@ -71,8 +70,6 @@ class ConnectionHandler(BaseRequestHandler):
         * Executes qick program
         * Return results
         """
-        # print a log message when receive a connection
-        logger.debug("Got connection from %s", self.client_address)
 
         # set the server in non-blocking mode
         self.server.socket.setblocking(False)


### PR DESCRIPTION
This should help in the flipping problem, where we probably reached the maximum number of instruction per program, and overall performances should also improve.

I did not have the opportunity to test it.

With this PR qibosoq will:
- [x] Not call `set_pulse_register` when not necessary
- [x] Qick supports adding multiple_pulses **before** firing them, this should also improve performances
- [x] Adding new log file with last executed qick_program in asm (this would make debug and communications with qick easier)

Checklist before merge:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
