### PR TITLE
remove dep from qibolab

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,6 @@ packages = [{ include = "qibosoq", from = "src" }]
 
 [tool.poetry.dependencies]
 python = ">=3.8, <3.12"
-# TODO replace with qibolab = "0.0.4" when released
-qibolab = { git = "https://github.com/qiboteam/qibolab.git", rev  = "7a9dbbaa"}
 qick = "^0.2"
 
 

--- a/src/qibosoq/abstracts.py
+++ b/src/qibosoq/abstracts.py
@@ -39,7 +39,7 @@ class Pulse:
     name: str
     type: str
 
-    shape: str
+    shape: str = None
     rel_sigma: float = None
     sigma: float = None
     beta: float = None

--- a/src/qibosoq/abstracts.py
+++ b/src/qibosoq/abstracts.py
@@ -1,0 +1,82 @@
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import List, Union
+
+
+@dataclass
+class Config:
+    """General RFSoC Configuration to send to the server"""
+
+    # sampling_rate: int = None
+    repetition_duration: int = 100_000
+    adc_trig_offset: int = 200
+    # max_gain: int = 32_000
+    reps: int = 1000
+    # adc_sampling_frequency: int = None
+    # mux_sampling_frequency: int = None
+
+
+@dataclass
+class Qubit:
+    bias: float = 0.0
+    dac: int = None
+
+
+# pulses
+
+
+@dataclass
+class Shape:
+    """shape"""
+
+
+@dataclass
+class Pulse:
+    frequency: float  # MHz
+    amplitude: float
+    relative_phase: int  # TODO check
+    start: float
+    duration: float
+    shape: Shape
+
+    dac: int
+    adc: int
+
+    name: str
+    type: str
+
+
+@dataclass
+class Gaussian:
+    rel_sigma: float
+
+
+@dataclass
+class Rectangular:
+    """rectangular"""
+
+
+@dataclass
+class Drag:
+    sigma: float
+    beta: float
+
+
+class Parameter(Enum):
+    frequency = auto()
+    amplitude = auto()
+    relative_phase = auto()
+    start = auto()
+
+    bias = auto()
+
+
+@dataclass
+class Sweeper:
+    """Sweeper object"""
+
+    expts: int = None  # single number of points
+    parameter: List[Parameter] = None  # parameter to sweep
+    starts: List[Union[int, float]] = None  # list of start values
+    stops: List[Union[int, float]] = None  # list of stops values
+    indexes: List[int] = None  # list of the indexes of the sweeped pulses or qubits

--- a/src/qibosoq/abstracts.py
+++ b/src/qibosoq/abstracts.py
@@ -38,21 +38,9 @@ class Pulse:
 
     name: str
     type: str
+
     shape: str
-
-
-@dataclass
-class Gaussian(Pulse):
     rel_sigma: float = None
-
-
-@dataclass
-class Rectangular(Pulse):
-    """rectangular"""
-
-
-@dataclass
-class Drag(Pulse):
     sigma: float = None
     beta: float = None
 

--- a/src/qibosoq/abstracts.py
+++ b/src/qibosoq/abstracts.py
@@ -26,40 +26,35 @@ class Qubit:
 
 
 @dataclass
-class Shape:
-    """shape"""
-
-
-@dataclass
 class Pulse:
     frequency: float  # MHz
     amplitude: float
     relative_phase: int  # TODO check
     start: float
     duration: float
-    shape: Shape
 
     dac: int
     adc: int
 
     name: str
     type: str
+    shape: str
 
 
 @dataclass
-class Gaussian:
-    rel_sigma: float
+class Gaussian(Pulse):
+    rel_sigma: float = None
 
 
 @dataclass
-class Rectangular:
+class Rectangular(Pulse):
     """rectangular"""
 
 
 @dataclass
-class Drag:
-    sigma: float
-    beta: float
+class Drag(Pulse):
+    sigma: float = None
+    beta: float = None
 
 
 class Parameter(Enum):

--- a/src/qibosoq/abstracts.py
+++ b/src/qibosoq/abstracts.py
@@ -34,15 +34,11 @@ class Pulse:
 
     name: str  # name of the pulse, typically a serial
     type: str  # 'readout', 'drive', 'flux'
-    shape: str  # 'rectangular', 'gaussian', 'drag'
 
     dac: int  # dac for pulse
     adc: int  # adc for readout pulse
 
-    name: str
-    type: str
-
-    shape: str = None
+    shape: str  # 'rectangular', 'gaussian', 'drag'
     rel_sigma: float = None
     sigma: float = None
     beta: float = None

--- a/src/qibosoq/abstracts.py
+++ b/src/qibosoq/abstracts.py
@@ -7,13 +7,9 @@ from typing import List, Union
 class Config:
     """General RFSoC Configuration to send to the server"""
 
-    # sampling_rate: int = None
     repetition_duration: int = 100_000
     adc_trig_offset: int = 200
-    # max_gain: int = 32_000
     reps: int = 1000
-    # adc_sampling_frequency: int = None
-    # mux_sampling_frequency: int = None
 
 
 @dataclass

--- a/src/qibosoq/abstracts.py
+++ b/src/qibosoq/abstracts.py
@@ -36,6 +36,9 @@ class Pulse:
     type: str  # 'readout', 'drive', 'flux'
     shape: str  # 'rectangular', 'gaussian', 'drag'
 
+    dac: int  # dac for pulse
+    adc: int  # adc for readout pulse
+
     name: str
     type: str
 

--- a/src/qibosoq/qick_programs.py
+++ b/src/qibosoq/qick_programs.py
@@ -99,7 +99,7 @@ class BaseProgram(ABC, QickProgram):
         """
 
         gen_ch = pulse.dac
-        max_gain = self.soccfg["gens"][gen_ch]["maxv"]  # TODO
+        max_gain = int(self.soccfg["gens"][gen_ch]["maxv"])  # TODO
 
         # assign gain parameter
         gain = int(pulse.amplitude * max_gain)
@@ -368,7 +368,9 @@ class FluxProgram(BaseProgram):
 
         for qubit in self.qubits:
             flux_ch = qubit.dac
-            max_gain = self.soccfg["gens"][flux_ch]["maxv"]
+            max_gain = int(self.soccfg["gens"][flux_ch]["maxv"])
+
+            logger.debug(f"set bias {qubit.bias} {max_gain}")
 
             if qubit.bias == 0:
                 continue  # if bias is zero, just skip the qubit
@@ -474,7 +476,7 @@ class ExecuteSweeps(FluxProgram, NDAveragerProgram):
                 swept_register = self.new_gen_reg(gen_ch, name=f"sweep_bias_{gen_ch}")
                 self.bias_sweep_registers[gen_ch] = (swept_register, std_register)
 
-                max_gain = self.soccfg["gens"][gen_ch]["maxv"]
+                max_gain = int(self.soccfg["gens"][gen_ch]["maxv"])
                 starts = (sweeper.starts * max_gain).astype(int)
                 stops = (sweeper.stops * max_gain).astype(int)
 
@@ -495,7 +497,7 @@ class ExecuteSweeps(FluxProgram, NDAveragerProgram):
                 register = self.get_gen_reg(gen_ch, sweep_type)
 
                 if sweeper.parameter[idx] is Parameter.amplitude:
-                    max_gain = self.soccfg["gens"][gen_ch]["maxv"]
+                    max_gain = int(self.soccfg["gens"][gen_ch]["maxv"])
                     starts = (sweeper.starts * max_gain).astype(int)
                     stops = (sweeper.stops * max_gain).astype(int)
 

--- a/src/qibosoq/qick_programs.py
+++ b/src/qibosoq/qick_programs.py
@@ -345,12 +345,8 @@ class BaseProgram(ABC, QickProgram):
 
         mux_dict = {}
         for pulse in [pulse for pulse in self.sequence if pulse.type == "readout"]:
-            logger.debug(mux_dict)
-            logger.debug(round(pulse.start, 5))
-
             if round(pulse.start, 5) not in mux_dict:
                 if len(mux_dict) > 0:
-                    logger.debug((pulse.start - list(mux_dict)[-1]) < 2)
                     if (pulse.start - list(mux_dict)[-1]) < 2:  # TODO not 2, but pulses len
                         mux_dict[round(pulse.start, 5)] = mux_dict[list(mux_dict)[-1]]
                         del mux_dict[list(mux_dict)[-2]]
@@ -358,7 +354,6 @@ class BaseProgram(ABC, QickProgram):
                         mux_dict[round(pulse.start, 5)] = []
                 else:
                     mux_dict[round(pulse.start, 5)] = []
-            logger.debug(mux_dict)
             mux_dict[round(pulse.start, 5)].append(pulse)
 
         self.readouts_per_experiment = len(mux_dict)
@@ -488,11 +483,10 @@ class ExecuteSweeps(FluxProgram, NDAveragerProgram):
         stops = sweeper.stops
 
         sweep_list = []
-        logger.debug(f"sweep par {sweeper.parameter} {sweeper.parameter is Parameter.bias}")
-        if sweeper.parameter is Parameter.bias:
+        if sweeper.parameter[0] is Parameter.bias:
             for idx, jdx in enumerate(sweeper.indexes):
                 gen_ch = self.qubits[jdx].dac
-                sweep_type = SWEEPERS_TYPE[sweeper.parameter]
+                sweep_type = SWEEPERS_TYPE[sweeper.parameter[0]]
                 std_register = self.get_gen_reg(gen_ch, sweep_type)
                 swept_register = self.new_gen_reg(gen_ch, name=f"sweep_bias_{gen_ch}")
                 self.bias_sweep_registers[gen_ch] = (swept_register, std_register)

--- a/src/qibosoq/qick_programs.py
+++ b/src/qibosoq/qick_programs.py
@@ -370,8 +370,6 @@ class FluxProgram(BaseProgram):
             flux_ch = qubit.dac
             max_gain = int(self.soccfg["gens"][flux_ch]["maxv"])
 
-            logger.debug(f"set bias {qubit.bias} {max_gain}")
-
             if qubit.bias == 0:
                 continue  # if bias is zero, just skip the qubit
             if mode == "sweetspot":

--- a/src/qibosoq/qick_programs.py
+++ b/src/qibosoq/qick_programs.py
@@ -273,7 +273,7 @@ class BaseProgram(ABC, QickProgram):
         adcs, adc_count = np.unique(adcs, return_counts=True)
 
         for idx, adc_ch in enumerate(adcs):
-            count = adc_count[adc_ch]
+            count = adc_count[idx]
             if self.expts:  # self.expts is None if this is not a sweep
                 shape = (count, self.expts, self.reps)
             else:

--- a/src/qibosoq/rfsoc_server.py
+++ b/src/qibosoq/rfsoc_server.py
@@ -12,6 +12,7 @@ from socketserver import BaseRequestHandler, TCPServer
 
 from qick import QickSoc
 
+from qibosoq.abstracts import Config, Pulse, Qubit, Sweeper
 from qibosoq.qick_programs import ExecutePulseSequence, ExecuteSweeps
 
 logger = logging.getLogger("__name__")
@@ -47,9 +48,20 @@ class ConnectionHandler(BaseRequestHandler):
             (dict): dictionary with two keys (i, q) to lists of values
         """
         if data["operation_code"] == "execute_pulse_sequence":
-            program = ExecutePulseSequence(global_soc, data["cfg"], data["sequence"], data["qubits"])
+            program = ExecutePulseSequence(
+                global_soc,
+                Config(**data["cfg"]),
+                [Pulse(**pulse) for pulse in data["sequence"]],
+                [Qubit(**qubit) for qubit in data["qubits"]],
+            )
         elif data["operation_code"] == "execute_sweeps":
-            program = ExecuteSweeps(global_soc, data["cfg"], data["sequence"], data["qubits"], data["sweepers"])
+            program = ExecuteSweeps(
+                global_soc,
+                Config(**data["cfg"]),
+                [Pulse(**pulse) for pulse in data["sequence"]],
+                [Qubit(**qubit) for qubit in data["qubits"]],
+                [Sweeper(**sweeper) for sweeper in data["sweepers"]],
+            )
         else:
             raise NotImplementedError(f"Operation code {data['operation_code']} not supported")
 

--- a/src/qibosoq/rfsoc_server.py
+++ b/src/qibosoq/rfsoc_server.py
@@ -39,6 +39,7 @@ class ConnectionHandler(BaseRequestHandler):
         count = int.from_bytes(self.request.recv(4), "big")
         received = self.request.recv(count, socket.MSG_WAITALL)
         data = pickle.loads(received)
+        logger.debug(data)
         return data
 
     def execute_program(self, data: dict) -> dict:

--- a/src/qibosoq/rfsoc_server.py
+++ b/src/qibosoq/rfsoc_server.py
@@ -68,14 +68,18 @@ class ConnectionHandler(BaseRequestHandler):
         qick_logger.handlers[0].doRollover()
         qick_logger.info(program.asm())
 
-        toti, totq = program.acquire(
-            global_soc,
-            data["readouts_per_experiment"],
-            load_pulses=True,
-            progress=False,
-            debug=False,
-            average=data["average"],
-        )
+        try:
+            toti, totq = program.acquire(
+                global_soc,
+                data["readouts_per_experiment"],
+                load_pulses=True,
+                progress=False,
+                debug=False,
+                average=data["average"],
+            )
+        except Exception as e:
+            global_soc.reset_gens()
+            raise (e)
 
         return {"i": toti, "q": totq}
 

--- a/src/qibosoq/rfsoc_server.py
+++ b/src/qibosoq/rfsoc_server.py
@@ -68,18 +68,14 @@ class ConnectionHandler(BaseRequestHandler):
         qick_logger.handlers[0].doRollover()
         qick_logger.info(program.asm())
 
-        try:
-            toti, totq = program.acquire(
-                global_soc,
-                data["readouts_per_experiment"],
-                load_pulses=True,
-                progress=False,
-                debug=False,
-                average=data["average"],
-            )
-        except Exception as e:
-            global_soc.reset_gens()
-            raise (e)
+        toti, totq = program.acquire(
+            global_soc,
+            data["readouts_per_experiment"],
+            load_pulses=True,
+            progress=False,
+            debug=False,
+            average=data["average"],
+        )
 
         return {"i": toti, "q": totq}
 


### PR DESCRIPTION
Qibosoq should not depend on qibolab, it should be the other way around. 
This will also avoid breaking the server every time an update on the client is done.

Checklist before review:
- [x] Qibolab/Qibocal works


Checklist before merge:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
