### PR TITLE
Fix config object

### DIFF
--- a/src/qibosoq/components.py
+++ b/src/qibosoq/components.py
@@ -15,6 +15,8 @@ class Config:
     """Time to wait between readout pulse and acquisition (ADC clock ticks)."""
     reps: int = 1000
     """Number of shots."""
+    soft_avgs: int = 1
+    """Number of software averages."""
 
 
 class OperationCode(IntEnum):

--- a/src/qibosoq/components.py
+++ b/src/qibosoq/components.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass, field
 from enum import IntEnum, auto
-from typing import List, Optional, Union
+from typing import List, Union
 
 
 @dataclass
@@ -15,8 +15,6 @@ class Config:
     """Time to wait between readout pulse and acquisition (ADC clock ticks)."""
     reps: int = 1000
     """Number of shots."""
-    soft_avgs: Optional[int] = None
-    """Number of software averages."""
 
 
 class OperationCode(IntEnum):

--- a/src/qibosoq/qick_programs.py
+++ b/src/qibosoq/qick_programs.py
@@ -460,10 +460,7 @@ class ExecuteSweeps(FluxProgram, NDAveragerProgram):
     ):
         """Init function, sets sweepers parameters before calling super.__init__."""
         # sweepers are handled by qick in the opposite order
-        if isinstance(sweepers, Sweeper):
-            self.sweepers = [sweepers]
-        else:
-            self.sweepers = list(sweepers)[::-1]
+        self.sweepers = [sweepers] if isinstance(sweepers, Sweeper) else list(sweepers)[::-1]
 
         # qpcfg.expts = sweeper.expts
         super().__init__(soc, qpcfg, sequence, qubits)

--- a/src/qibosoq/qick_programs.py
+++ b/src/qibosoq/qick_programs.py
@@ -460,7 +460,10 @@ class ExecuteSweeps(FluxProgram, NDAveragerProgram):
     ):
         """Init function, sets sweepers parameters before calling super.__init__."""
         # sweepers are handled by qick in the opposite order
-        self.sweepers = list(sweepers)[::-1]
+        if isinstance(sweepers, Sweeper):
+            self.sweepers = [sweepers]
+        else:
+            self.sweepers = list(sweepers)[::-1]
 
         # qpcfg.expts = sweeper.expts
         super().__init__(soc, qpcfg, sequence, qubits)


### PR DESCRIPTION
I added soft_avgs for raw acquisition, but if it's defined as None then will throw errors. There is no need of having the parameter there in any case, I will simply add it to the dictionary if needed.

Checklist before merge:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Documentation is updated.
