### PR TITLE
Check memory of tproc is not filled, raise informative error

### DIFF
--- a/src/qibosoq/components.py
+++ b/src/qibosoq/components.py
@@ -78,6 +78,7 @@ class Parameter(IntEnum):
     RELATIVE_PHASE = auto()
     START = auto()
     BIAS = auto()
+    DURATION = auto()
 
 
 @dataclass

--- a/src/qibosoq/rfsoc_server.py
+++ b/src/qibosoq/rfsoc_server.py
@@ -71,7 +71,7 @@ class ConnectionHandler(BaseRequestHandler):
         qick_logger.handlers[0].doRollover()
         qick_logger.info(asm_prog)
 
-        num_instructions = asm_prog.count("\n") - 2
+        num_instructions = len(program.prog_list)
         max_mem = self.server.qick_soc["tprocs"][0]["pmem_size"]
         if num_instructions > max_mem:
             raise MemoryError(

--- a/src/qibosoq/rfsoc_server.py
+++ b/src/qibosoq/rfsoc_server.py
@@ -67,8 +67,16 @@ class ConnectionHandler(BaseRequestHandler):
             *args,
         )
 
+        asm_prog = program.asm()
         qick_logger.handlers[0].doRollover()
-        qick_logger.info(program.asm())
+        qick_logger.info(asm_prog)
+
+        num_instructions = asm_prog.count("\n") - 2
+        max_mem = self.server.qick_soc["tprocs"][0]["pmem_size"]
+        if num_instructions > max_mem:
+            raise MemoryError(
+                f"The tproc has a max memory size of {max_mem}, but the program had {num_instructions} instructions"
+            )
 
         if opcode is OperationCode.EXECUTE_PULSE_SEQUENCE_RAW:
             results = program.acquire_decimated(


### PR DESCRIPTION
I tried to run standard RB (with a non-calibrated qubit, just to see if the memory problem was solved) and it's not.
As I explained some time ago, there are two memories that can cause problems if filled: the DAC memory (that stores waveforms) and the tproc memory (that store the program). 
I solved the DAC memory problem for a standard program that doesn't use too many different waveforms, but the tproc still has the same limits. 
Note that the problem affects the two boards in very different ways: the RFSoC4x2 has 1024 memory limit (around 70 pulses), while the ZCU111 has a 8192 memory (around 560 pulses).

I have an idea to increase the maximum number of pulses, but in qibosoq it would probably appear as a weird patch. I am thinking about directly opening an issue and PR in qick (but maybe in the future).

In the moment, I added a check for the tproc memory so that eventually a much more informative error gets raised.

Checklist before merge:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Documentation is updated.
