### PR TITLE
Fix time registers

### DIFF
--- a/src/qibosoq/programs/sweepers.py
+++ b/src/qibosoq/programs/sweepers.py
@@ -94,7 +94,7 @@ class ExecuteSweeps(FluxProgram, NDAveragerProgram):
                     max_gain = int(self.soccfg["gens"][gen_ch]["maxv"])
                     starts = (sweeper.starts * max_gain).astype(int)
                     stops = (sweeper.stops * max_gain).astype(int)
-                elif sweeper.parameter[idx] is Parameter.START:
+                elif sweeper.parameters[idx] is Parameter.START:
                     # TODO tell qick of the mismatch (t != time)
                     register.reg_type = "time"
 

--- a/src/qibosoq/programs/sweepers.py
+++ b/src/qibosoq/programs/sweepers.py
@@ -94,6 +94,9 @@ class ExecuteSweeps(FluxProgram, NDAveragerProgram):
                     max_gain = int(self.soccfg["gens"][gen_ch]["maxv"])
                     starts = (sweeper.starts * max_gain).astype(int)
                     stops = (sweeper.stops * max_gain).astype(int)
+                elif sweeper.parameter[idx] is Parameter.START:
+                    # TODO tell qick of the mismatch (t != time)
+                    register.reg_type = "time"
 
                 new_sweep = QickSweep(
                     self,


### PR DESCRIPTION
Time-Sweepers are not correctly understood by qick since there is a mismatch in name: sometimes they are called "t" registers and sometimes "time" registers. This fixes the problem

Checklist before merge:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Documentation is updated.
