### PR TITLE
Add support for interpolated channel

### DIFF
--- a/src/qibosoq/components/pulses.py
+++ b/src/qibosoq/components/pulses.py
@@ -58,6 +58,9 @@ class Pulse(Element):
     type: str
     """Can be 'readout', 'drive', 'flux'."""
 
+    mixer_frequency: Optional[int] = None
+    """Mixer frequency for interpolated channels."""
+
 
 @dataclass
 class Rectangular(Pulse):
@@ -75,7 +78,7 @@ class Rectangular(Pulse):
 class Gaussian(Pulse):
     """Gaussian pulse."""
 
-    rel_sigma: float
+    rel_sigma: float = 2.0
     """Sigma of the gaussian as a fraction of duration."""
     shape: str = "gaussian"
 
@@ -89,9 +92,9 @@ class Gaussian(Pulse):
 class Drag(Pulse):
     """Drag pulse."""
 
-    rel_sigma: float
+    rel_sigma: float = 2.0
     """Sigma of the drag as a fraction of duration."""
-    beta: float
+    beta: float = 0.1
     """Beta parameter for drag pulse."""
     shape: str = "drag"
 
@@ -108,7 +111,7 @@ class Drag(Pulse):
 class FlatTop(Pulse):
     """FlatTop pulse."""
 
-    rel_sigma: float
+    rel_sigma: float = 2.0
     """Sigma of the FlatTop as a fraction of duration."""
     shape: str = "flattop"
 
@@ -129,9 +132,9 @@ class FlatTop(Pulse):
 class FluxExponential(Pulse):
     """Flux pulse with exponential rising edge to correct distortions."""
 
-    tau: float
-    upsilon: float
-    weight: float
+    tau: float = 0.1
+    upsilon: float = 0.1
+    weight: float = 0.1
     shape: str = "fluxexponential"
 
     def i_values(self, duration: int, max_gain: int):
@@ -148,8 +151,8 @@ class FluxExponential(Pulse):
 class Arbitrary(Pulse):
     """Custom pulse."""
 
-    i_values: List[float]
-    q_values: List[float]
+    i_values: List[float] = field(default_factory=list)
+    q_values: List[float] = field(default_factory=list)
     shape: str = "arbitrary"
 
     @property

--- a/src/qibosoq/programs/base.py
+++ b/src/qibosoq/programs/base.py
@@ -91,7 +91,10 @@ class BaseProgram(ABC, QickProgram):
                 ch_already_declared.append(gen_ch)
                 sampling_rate = self.soccfg["gens"][gen_ch]["fs"]
                 zone = 1 if freq < sampling_rate / 2 else 2
-                self.declare_gen(gen_ch, nqz=zone)
+                if pulse.mixer_frequency is not None:
+                    self.declare_gen(gen_ch, nqz=zone, mixer_freq=pulse.mixer_frequency)
+                else:
+                    self.declare_gen(gen_ch, nqz=zone)
 
     def declare_readout_freq(self):
         """Declare ADCs downconversion frequencies."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -95,6 +95,7 @@ def targ_server_commands():
                 "type": "drive",
                 "dac": 0,
                 "adc": None,
+                "mixer_frequency": None,
             },
             {
                 "shape": "rectangular",
@@ -107,6 +108,7 @@ def targ_server_commands():
                 "type": "readout",
                 "dac": 1,
                 "adc": 0,
+                "mixer_frequency": None,
             },
         ],
         "qubits": [


### PR DESCRIPTION
I'm adding support for the interpolated channel. 
This is an easy solution (that should work), but I do not like it much... It is not much clean and does not scale considering the addition of new type of channels (what will I do, continuously add new attributes?).
Moreover, it does not solve the problem of having normal readout channels as well as the multiplexed ones.
I'm going to think about it a bit more, but in the meantime this is fine.

Checklist before review:
- [ ] Add support in qibolab
- [ ] Test on hardware
- [ ] Documentation is updated.

Checklist before merge:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.

