### PR TITLE
Add support for external clock reference

### DIFF
--- a/doc/source/getting-started/usage.rst
+++ b/doc/source/getting-started/usage.rst
@@ -23,7 +23,8 @@ A list of the configurable variables (with values set to the default ones) is th
    export QIBOSOQ_BITSTREAM=/usr/local/share/pynq-venv/lib/python3.10/site-packages/qick/qick_111.bit
    # is the readout multiplexed?
    export QIBOSOQ_IS_MULTIPLEXED=False
-
+   # is an external clock used as a reference?
+   export QIBOSOQ_EXT_CLK=False
 
 Running the server
 """"""""""""""""""
@@ -80,3 +81,14 @@ Some examples are:
           echo "No running server"
       fi
     }
+
+External clock reference
+""""""""""""""""""""""""
+
+It is possible to provide an external clock reference to the board, allowing all clocks to be synchronized with other instruments.
+
+- For the **RFSoC4x2**, connect a 10 MHz reference to the **CLK_IN** SMA input.
+- For the **ZCU111**, provide a 12.8 MHz reference on **External_REF_CLK**.
+- For the **ZCU216**, supply a 10 MHz reference to **INPUT_REF_CLK**.
+
+Note that, for the external reference to be detected, the environment variable `QIBOSOQ_EXT_CLK` must be set to `True`.

--- a/src/qibosoq/configuration.py
+++ b/src/qibosoq/configuration.py
@@ -31,5 +31,8 @@ QICKSOC_LOCATION = from_env(
 )
 """Path of the qick bitstream to load."""
 
+EXT_CLK = from_env("EXT_CLK", "False") == "True"
+"""Whether the external clock is used as a reference or not."""
+
 IS_MULTIPLEXED = from_env("IS_MULTIPLEXED", "True") == "True"
 """Whether the readout is multiplexed or not."""

--- a/src/qibosoq/server.py
+++ b/src/qibosoq/server.py
@@ -159,6 +159,8 @@ def serve(host, port):
     # initialize QickSoc object (firmware and clocks)
     TCPServer.allow_reuse_address = True
     with TCPServer((host, port), ConnectionHandler) as server:
-        server.qick_soc = QickSoc(bitfile=cfg.QICKSOC_LOCATION)
+        server.qick_soc = QickSoc(
+            bitfile=cfg.QICKSOC_LOCATION, external_clk=cfg.EXT_CLK
+        )
         log_initial_info()
         server.serve_forever()


### PR DESCRIPTION
This is also an addition suggested by FBK that is currently using a patched version of qibosoq for this feature.
Anyway this should work, but I'd like to briefly test it before merging

Checklist before merge:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Documentation is updated.
