### PR TITLE
clean grouping of mux readouts

### DIFF
--- a/src/qibosoq/programs/base.py
+++ b/src/qibosoq/programs/base.py
@@ -359,17 +359,14 @@ class BaseProgram(ABC, QickProgram):
         group: List[Element] = []
 
         for pulse in self.sequence:
-            if pulse.type != "readout":
+            readout = pulse.type != "readout"
+            if readout or pulse.start_delay != 0:
                 if group:
                     mux_list.append(group)
                     group = []
-                continue
 
-            if pulse.start_delay != 0:
-                if group:
-                    mux_list.append(group)
-                    group = []
-            group.append(pulse)
+            if !readout:
+                group.append(pulse)
 
         if group:
             mux_list.append(group)

--- a/src/qibosoq/programs/base.py
+++ b/src/qibosoq/programs/base.py
@@ -357,7 +357,7 @@ class BaseProgram(ABC, QickProgram):
         """
         mux_list: List[List[Element]] = []
 
-        group = []
+        group: List[Element] = []
         for pulse in self.sequence:
             if pulse.type == "readout":
                 if pulse.start_delay != 0:

--- a/src/qibosoq/programs/base.py
+++ b/src/qibosoq/programs/base.py
@@ -359,13 +359,13 @@ class BaseProgram(ABC, QickProgram):
         group: List[Element] = []
 
         for pulse in self.sequence:
-            readout = pulse.type != "readout"
-            if readout or pulse.start_delay != 0:
+            readout = pulse.type == "readout"
+            if (not readout) or pulse.start_delay != 0:
                 if len(group) > 0:
                     mux_list.append(group)
                     group = []
 
-            if not readout:
+            if readout:
                 group.append(pulse)
 
         if len(group) > 0:

--- a/src/qibosoq/programs/base.py
+++ b/src/qibosoq/programs/base.py
@@ -352,18 +352,32 @@ class BaseProgram(ABC, QickProgram):
 
         Example of list:
         [[pulse1, pulse2], [pulse3]]
+
+        Readout pulses are considered to be correctly organized.
         """
         mux_list: List[List[Element]] = []
-        len_last_readout = 0.0
-        for pulse in (pulse for pulse in self.sequence if pulse.type == "readout"):
-            if pulse.start_delay <= len_last_readout and len(mux_list) > 0:
-                # add the pulse to the last multiplexed readout
-                mux_list[-1].append(pulse)
-            else:
-                # add a new multiplexed readout
-                mux_list.append([pulse])
-            len_last_readout = pulse.duration
 
+        group = []
+        for pulse in self.sequence:
+            if pulse.type == "readout":
+                if pulse.start_delay != 0:
+                    if len(group) != 0:
+                        mux_list.append(group)
+                        group = []
+                    group = [pulse]
+                else:
+                    group.append(pulse)
+        if len(group) != 0:
+            mux_list.append(group)
+
+        # check that all the readout pulses share the same duration
+        for group in mux_list:
+            length = group[0].duration
+            for pulse in group[1:]:
+                if not length == pulse.duration:
+                    raise RuntimeError(
+                        f"Muxed readout pulses must share same duration.: {mux_list}"
+                    )
         return mux_list
 
     @abstractmethod

--- a/src/qibosoq/programs/base.py
+++ b/src/qibosoq/programs/base.py
@@ -361,14 +361,14 @@ class BaseProgram(ABC, QickProgram):
         for pulse in self.sequence:
             readout = pulse.type != "readout"
             if readout or pulse.start_delay != 0:
-                if group:
+                if len(group) > 0:
                     mux_list.append(group)
                     group = []
 
-            if !readout:
+            if not readout:
                 group.append(pulse)
 
-        if group:
+        if len(group) > 0:
             mux_list.append(group)
 
         # check that all the readout pulses share the same duration

--- a/tests/test_programs_base.py
+++ b/tests/test_programs_base.py
@@ -66,7 +66,7 @@ def execute_pulse_sequence(soc):
             type="readout",
             frequency=100,
             start_delay=0,
-            duration=0.03,
+            duration=0.04,
             adc=0,
             dac=6,
         ),
@@ -105,7 +105,7 @@ def test_declare_nqz_zones(execute_pulse_sequence):
             type="readout",
             frequency=100,
             start_delay=0,
-            duration=0.03,
+            duration=0.04,
             adc=0,
             dac=6,
         ),
@@ -279,8 +279,8 @@ def test_execute_readout_pulse(soc):
             frequency=100,
             amplitude=0.1,
             relative_phase=0,
-            start_delay=0.5,
-            duration=0.04,
+            start_delay=0,
+            duration=1,
             name="pulse2",
             type="readout",
             dac=6,
@@ -331,6 +331,11 @@ def test_execute_readout_pulse(soc):
     if program.is_mux:
         assert len(muxed_pulse_executed) == 4
         assert muxed_ro_executed_indexes == [0, 1]
+
+    if program.is_mux:
+        sequence[-1].duration = 0.03
+        with pytest.raises(RuntimeError):
+            program = ExecutePulseSequence(soc, config, sequence, qubits)
 
 
 @pytest.mark.parametrize("avg", [True, False])


### PR DESCRIPTION
Closes #128 

My solution in the end is to first group the readout if they start exactly at the same time and then check if they share the same duration.
I am letting QICK handle other type of exceptions