### PR TITLE
Developer mode installation script

### DIFF
--- a/dev-install.bash
+++ b/dev-install.bash
@@ -1,0 +1,11 @@
+prog=$(
+	cat <<'EOF'
+		/^\]/ { if (s) e=1 }
+		s && !e { match($0, /".*"/); print substr($0, RSTART+1, RLENGTH-2) }
+		/^dependencies/ { s=1 }
+EOF
+)
+awk "$prog" pyproject.toml >qibosoq-requirements.txt
+
+pip install -r qibosoq-requirements.txt
+rm qibosoq-requirements.txt

--- a/dev-install.bash
+++ b/dev-install.bash
@@ -1,11 +1,24 @@
-prog=$(
+find_deps=$(
 	cat <<'EOF'
 		/^\]/ { if (s) e=1 }
 		s && !e { match($0, /".*"/); print substr($0, RSTART+1, RLENGTH-2) }
 		/^dependencies/ { s=1 }
 EOF
 )
-awk "$prog" pyproject.toml >qibosoq-requirements.txt
+awk "$find_deps" pyproject.toml >qibosoq-requirements.txt
 
 pip install -r qibosoq-requirements.txt
 rm qibosoq-requirements.txt
+
+find_path=$(
+	cat <<-'EOF'
+		import sys
+
+		print([x for x in sys.path if "site-packages" in x][-1])
+	EOF
+)
+env_path=$(python3 -c "$find_path")
+project_dir=$(dirname "$0")
+package_path=$(realpath "$project_dir")/src
+
+echo "$package_path" >"$env_path/qibosoq.pth"

--- a/dev-install.bash
+++ b/dev-install.bash
@@ -1,25 +1,27 @@
 #!/usr/bin/env bash
 
+PYTHON=/usr/local/share/pynq-venv/bin/python
+
 find_deps=$(
-	cat <<'EOF'
-		/^\]/ { if (s) e=1 }
-		s && !e { match($0, /".*"/); print substr($0, RSTART+1, RLENGTH-2) }
-		/^dependencies/ { s=1 }
+        cat <<'EOF'
+                /^\]/ { if (s) e=1 }
+                s && !e { match($0, /".*"/); print substr($0, RSTART+1, RLENGTH-2) }
+                /^dependencies/ { s=1 }
 EOF
 )
 awk "$find_deps" pyproject.toml >qibosoq-requirements.txt
 
-pip install -r qibosoq-requirements.txt
+sudo -E $PYTHON -m pip install -r qibosoq-requirements.txt
 rm qibosoq-requirements.txt
 
 find_path=$(
-	cat <<-'EOF'
-		import sys
+        cat <<-'EOF'
+                import sys
 
-		print([x for x in sys.path if "site-packages" in x][-1])
-	EOF
+                print([x for x in sys.path if "site-packages" in x][-1])
+        EOF
 )
-env_path=$(python3 -c "$find_path")
+env_path=$($PYTHON -c "import site; print(site.getsitepackages()[0])")
 project_dir=$(dirname "$0")
 package_path=$(realpath "$project_dir")/src
 

--- a/dev-install.bash
+++ b/dev-install.bash
@@ -14,13 +14,6 @@ awk "$find_deps" pyproject.toml >qibosoq-requirements.txt
 sudo -E $PYTHON -m pip install -r qibosoq-requirements.txt
 rm qibosoq-requirements.txt
 
-find_path=$(
-        cat <<-'EOF'
-                import sys
-
-                print([x for x in sys.path if "site-packages" in x][-1])
-        EOF
-)
 env_path=$($PYTHON -c "import site; print(site.getsitepackages()[0])")
 project_dir=$(dirname "$0")
 package_path=$(realpath "$project_dir")/src

--- a/dev-install.bash
+++ b/dev-install.bash
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 find_deps=$(
 	cat <<'EOF'
 		/^\]/ { if (s) e=1 }

--- a/dev-uninstall.bash
+++ b/dev-uninstall.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+PYTHON=/usr/local/share/pynq-venv/bin/python
+
+env_path=$($PYTHON -c "import site; print(site.getsitepackages()[0])")
+rm "$env_path/qibosoq.pth"
+
+echo "File qibosoq.pth removed from site-packages"

--- a/doc/source/getting-started/installation.rst
+++ b/doc/source/getting-started/installation.rst
@@ -41,3 +41,11 @@ Now the installation can be done in normal mode or in developer mode (using ``po
 
     sudo -E python -m pip install <path_to_qibosoq>  # normal mode
     sudo -E python -m poetry install <path_to_qibosoq> # developer mode
+
+Finally, on boards running with ``Python 3.8`` the standard installation method for developer mode does not work,
+since it requires a version of Poetry not supported. In this case, it is mandatory to pass through the provided
+legacy installation script via sudo:
+
+.. code-block:: bash
+
+    sudo <path_to_qibosoq>/qibosoq/dev-install.bash

--- a/doc/source/getting-started/installation.rst
+++ b/doc/source/getting-started/installation.rst
@@ -49,3 +49,9 @@ legacy installation script via sudo:
 .. code-block:: bash
 
     sudo <path_to_qibosoq>/qibosoq/dev-install.bash
+
+And to uninstall it:
+
+.. code-block:: bash
+
+    sudo <path_to_qibosoq>/qibosoq/dev-uninstall.bash

--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751987173,
-        "narHash": "sha256-cQjuqyNLKcqcLbZFvTKYSOXDuXIH6SbrGyk1r7l/wb8=",
+        "lastModified": 1757570236,
+        "narHash": "sha256-Gy15+KtKc/MyT4L9Ad/2wkXQvDiMkhtKy9Tnn3+kPww=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "9b4d2b5a4f650994045d6752de2ec48c1d9437a4",
+        "rev": "c57bded76fa6a885ab1dee2c75216cc23d58b311",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1751413152,
-        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
         "type": "github"
       },
       "original": {
@@ -125,10 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749636823,
+        "lastModified": 1750779888,
+        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "623c56286de5a3193aa38891a6991b28f9bab056",
+        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
         "type": "github"
       },
       "original": {
@@ -147,6 +148,7 @@
       },
       "locked": {
         "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
         "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
@@ -169,7 +171,10 @@
           "devenv",
           "git-hooks"
         ],
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
         "nixpkgs-23-11": [
           "devenv"
         ],
@@ -178,11 +183,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750955511,
-        "narHash": "sha256-IDB/oh/P63ZTdhgSkey2LZHzeNhCdoKk+4j7AaPe1SE=",
+        "lastModified": 1755029779,
+        "narHash": "sha256-3+GHIYGg4U9XKUN4rg473frIVNn8YD06bjwxKS1IPrU=",
         "owner": "cachix",
         "repo": "nix",
-        "rev": "afa41b08df4f67b8d77a8034b037ac28c71c77df",
+        "rev": "b0972b0eee6726081d10b1199f54de6d2917f861",
         "type": "github"
       },
       "original": {
@@ -194,11 +199,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747179050,
-        "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
+        "lastModified": 1757487488,
+        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "adaa24fbf46737f3f1b5497bf64bae750f82942e",
+        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
         "type": "github"
       },
       "original": {
@@ -210,32 +215,16 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1751159883,
-        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1751792365,
-        "narHash": "sha256-J1kI6oAj25IG4EdVlg2hQz8NZTBNYvIS0l4wpr9KcUo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1fd8bada0b6117e6c7eb54aad5813023eed37ccb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -243,7 +232,7 @@
       "inputs": {
         "devenv": "devenv",
         "flake-parts": "flake-parts_2",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/src/qibosoq/__init__.py
+++ b/src/qibosoq/__init__.py
@@ -1,5 +1,8 @@
 """qibosoq module."""
 
-import importlib.metadata as im
+try:
+    import importlib.metadata as im
 
-__version__ = im.version(__package__)
+    __version__ = im.version(__package__)
+except im.PackageNotFoundError:
+    __version__ = "0.0.0-dev"


### PR DESCRIPTION
After discussion with @rodolfocarobene, this partly reconsiders the proposed solution for #145.

In particular, in https://github.com/qiboteam/qibosoq/issues/145#issuecomment-3087827498 I proposed to build the package with one Python version - recent enough to be compatible with Poetry 2, required for the current manifest layout - and then install with a different one - old enough to be supported by PYNQ.

While this is a working solution, it is terribly annoying when working in development mode on the board, since it requires working with two different python versions (the recent one to be installed separately), and reinstall every time a change wants to be tested. Or do the same while developing on a separate machine, always uploading the built package there.

Thus, this PR provides a script which bypass Poetry for installation, extracting the dependencies from the manifest, and installing them with bare `pip`.
At the same time, it generates a `qibosoq.pth` file in the environment, the same which would have been provided by `pip install -e` or `poetry install`. This file redirects Python imports, effectively adding the project's folder to the searched library path.